### PR TITLE
added ffmpeg to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-alpine
 COPY . /app
 WORKDIR /app
 
-RUN apk --no-cache add gcc libc-dev \
+RUN apk --no-cache add gcc libc-dev ffmpeg \
 	&& pip3 install .
 
 VOLUME ["/data"]


### PR DESCRIPTION
Since the `--transcode` flag invokes `ffmpeg` the latest Docker image fails. So I just added it.


Related: https://github.com/Yetangitu/Spodcast/issues/4