### PR TITLE
Docker-Compose and Other Docker Images

### DIFF
--- a/docker/Dockerfile.cron
+++ b/docker/Dockerfile.cron
@@ -1,17 +1,6 @@
-FROM python:3-alpine
+FROM heywoodlh/spodcast:latest
 
-COPY . /app
-WORKDIR /app
-
-RUN apk --no-cache add gcc libc-dev ffmpeg bash \
-	&& pip3 install .
-
-VOLUME ["/data"]
-WORKDIR /data
-
-COPY docker/run.sh /run.sh
-
-ENTRYPOINT ["/run.sh"]
+COPY docker/cron.sh /cron.sh
 
 LABEL description="Spodcast is a caching Spotify podcast to RSS proxy. \
 Using Spodcast you can follow Spotify-hosted netcasts/podcasts using any \
@@ -20,3 +9,4 @@ is not compatible with the Spotify (web) app."
 LABEL version="0.5.2"
 LABEL org.opencontainers.image.authors="Yetangitu and others"
 
+ENTRYPOINT /cron.sh

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,0 +1,9 @@
+FROM nginx:stable
+
+RUN apt-get update && apt-get install -y nginx-full \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm /etc/nginx/conf.d/default.conf \
+	&& rm /etc/nginx/sites-enabled/default
+
+COPY docker/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY docker/nginx/sites-enabled /etc/nginx/sites-enabled

--- a/docker/cron.sh
+++ b/docker/cron.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+## Set default cron schedule
+[[ -n ${CRON_SCHEDULE} ]] || export CRON_SCHEDULE="0 0 * * Sun"
+
+## Variables for /run.sh
+[[ -n ${SPODCAST_ROOT} ]] || export SPODCAST_ROOT='/data'
+[[ -n ${SPODCAST_HTML} ]] || export SPODCAST_HTML="${SPODCAST_ROOT}/html"
+[[ -n ${SPODCAST_CONFIG_JSON} ]] || export SPODCAST_CONFIG_JSON="${SPODCAST_ROOT}/spodcast.json"
+[[ -n ${SPOTIFY_CREDS_JSON} ]] || export SPOTIFY_CREDS_JSON="${SPODCAST_ROOT}/creds.json"
+[[ -n ${SPOTIFY_RC_PATH} ]] || export SPOTIFY_RC_PATH="${SPODCAST_ROOT}/spotify.rc"
+[[ -n ${SPOTIFY_PASSWORD} ]] || export creds_supplied='false'
+[[ -n ${SPOTIFY_USERNAME} ]] || export creds_supplied='false'
+[[ -n ${MAX_EPISODES} ]] || export MAX_EPISODES='10'
+[[ -n ${LOG_LEVEL} ]] || export LOG_LEVEL='info'
+[[ -n ${CHUNK_SIZE} ]] || export CHUNK_SIZE='50000'
+[[ -n ${RSS_FEED} ]] || export RSS_FEED='yes'
+[[ -n ${TRANSCODE} ]] || export TRANSCODE='no'
+[[ -n ${LANGUAGE} ]] || export LANGUAGE='en'
+[[ -n ${SKIP_EXISTING} ]] || export SKIP_EXISTING='yes'
+
+[[ ${creds_supplied} == 'false' ]] \
+    && echo 'Please set the SPOTIFY_USERNAME and SPOTIFY_PASSWORD variables. Exiting.' \
+    && exit 1
+
+## Setup cron
+echo SHELL=/bin/bash > /tmp/cron
+echo PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin >> /tmp/cron
+echo "${CRON_SCHEDULE} SPODCAST_ROOT=\"${SPODCAST_ROOT}\" SPODCAST_HTML=\"${SPODCAST_HTML}\" SPODCAST_CONFIG_JSON=\"${SPODCAST_CONFIG_JSON}\" SPOTIFY_CREDS_JSON=\"${SPOTIFY_CREDS_JSON}\" SPOTIFY_RC_PATH=\"${SPOTIFY_RC_PATH}\" SPOTIFY_PASSWORD=\"${SPOTIFY_PASSWORD}\" SPOTIFY_USERNAME=\"${SPOTIFY_USERNAME}\" MAX_EPISODES=\"${MAX_EPISODES}\" LOG_LEVEL=\"${LOG_LEVEL}\" CHUNK_SIZE=\"${CHUNK_SIZE}\" RSS_FEED=\"${RSS_FEED}\" TRANSCODE=\"${TRANSCODE}\" LANGUAGE=\"${LANGUAGE}\" SKIP_EXISTING=\"${SKIP_EXISTING}\" /run.sh"  >> /tmp/cron
+
+echo "* * * * * chown -R 101:101 ${SPODCAST_HTML}" >> /tmp/cron
+
+crontab /tmp/cron
+rm /tmp/cron
+
+crond -l 0 -d 0 -f

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  spodcast-cron:
+    image: heywoodlh/spodcast-cron:latest
+    volumes:
+      - spodcast_data:/data
+    restart: unless-stopped
+    environment:
+      - CRON_SCHEDULE=0 * * * *
+      - SPOTIFY_PODCAST_URLS=https://open.spotify.com/show/4rOoJ6Egrf8K2IrywzwOMk
+      - SPOTIFY_PASSWORD=myawesomepassword
+      - SPOTIFY_USERNAME=email@awesome.com
+      - MAX_EPISODES=1
+      
+  spodcast-php:
+    image: php:7-fpm
+    volumes:
+      - spodcast_data:/data
+    restart: unless-stopped
+    user: "101:101"
+    networks:
+    - spodcast
+
+  spodcast-web:
+    image: heywoodlh/spodcast-web:latest
+    volumes:
+      - spodcast_data:/data
+    restart: unless-stopped
+    networks:
+    - spodcast
+    ports:
+      - 8080:80
+
+networks:
+  spodcast:
+volumes:
+  spodcast_data:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,27 @@
+user  nginx;
+worker_processes  auto;
+
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+}

--- a/docker/nginx/sites-enabled/spodcast
+++ b/docker/nginx/sites-enabled/spodcast
@@ -1,0 +1,23 @@
+server {
+        listen 80;
+        listen [::]:80;
+
+        root /data/html;
+	
+        index .index.php;
+
+        # these files should not be accessible
+        location ~\.(json|info)$ {
+                deny all;
+                return 404;
+        }
+
+        location / {
+                try_files $uri $uri/ =404;
+        }
+
+        location ~ \.php$ {
+                include snippets/fastcgi-php.conf;
+                fastcgi_pass spodcast-php:9000;
+        }
+}

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+## If the following variables are not defined, set defaults
+[[ -n ${SPODCAST_ROOT} ]] || export SPODCAST_ROOT='/data'
+[[ -n ${SPODCAST_HTML} ]] || export SPODCAST_HTML="${SPODCAST_ROOT}/html"
+[[ -n ${SPODCAST_CONFIG_JSON} ]] || export SPODCAST_CONFIG_JSON="${SPODCAST_ROOT}/spodcast.json"
+[[ -n ${SPOTIFY_CREDS_JSON} ]] || export SPOTIFY_CREDS_JSON="${SPODCAST_ROOT}/creds.json"
+[[ -n ${SPOTIFY_RC_PATH} ]] || export SPOTIFY_RC_PATH="${SPODCAST_ROOT}/spotify.rc"
+[[ -n ${SPOTIFY_PASSWORD} ]] || export creds_supplied='false'
+[[ -n ${SPOTIFY_USERNAME} ]] || export creds_supplied='false'
+[[ -n ${MAX_EPISODES} ]] || export MAX_EPISODES='10'
+[[ -n ${LOG_LEVEL} ]] || export LOG_LEVEL='info'
+[[ -n ${CHUNK_SIZE} ]] || export CHUNK_SIZE='50000'
+[[ -n ${RSS_FEED} ]] || export RSS_FEED='yes'
+[[ -n ${TRANSCODE} ]] || export TRANSCODE='no'
+[[ -n ${LANGUAGE} ]] || export LANGUAGE='en'
+[[ -n ${SKIP_EXISTING} ]] || export SKIP_EXISTING='yes'
+
+## If Spotify credentials were supplied, create ${SPODCAST_ROOT}/spotify.rc
+[[ ${creds_supplied} == 'false' ]] || echo "${SPOTIFY_USERNAME} ${SPOTIFY_PASSWORD}" > ${SPODCAST_ROOT}/spotify.rc
+
+## If no arguments were supplied, then use environment variables
+if [[ -z "$@" ]]
+then
+	## If SPOTIFY_PODCAST_URLS is defined, then run Spodcast
+	if [[ -n ${SPOTIFY_PODCAST_URLS} ]]
+	then
+		## If ${SPOTIFY_RC_PATH} file exists
+		if [[ -e ${SPOTIFY_RC_PATH} ]]
+		then
+		# Login first and then run spodcast
+			/usr/local/bin/spodcast \
+				-c "${SPODCAST_CONFIG_JSON}" \
+				--root-path "${SPODCAST_HTML}" \
+				--log-level "${LOG_LEVEL}" \
+				--credentials-location "${SPOTIFY_CREDS_JSON}" \
+				-p -l ${SPOTIFY_RC_PATH} \
+				&& /usr/local/bin/spodcast \
+					-c ${SPODCAST_CONFIG_JSON} \
+					--log-level ${LOG_LEVEL} \
+					--max-episodes ${MAX_EPISODES} \
+					"${SPOTIFY_PODCAST_URLS}"
+		else
+			echo "SPOTIFY_PODCAST_URLS is defined, but no credentials were detected. Please set the SPOTIFY_USERNAME and SPOTIFY_PASSWORD variables."
+			exit 1
+		fi
+	## If SPOTIFY_PODCAST_URLS is not defined and no arguments were supplied, just show the help message
+	else
+		/usr/local/bin/spodcast --help	
+	fi
+fi
+
+## If arguments were supplied, do not use environment variables
+[[ -n $@ ]] && /usr/local/bin/spodcast "$@"


### PR DESCRIPTION
For https://github.com/Yetangitu/Spodcast/issues/15


Per my testing, the `docker-compose.yml` file works out of the box with the following caveats:
- https://github.com/Yetangitu/Spodcast/issues/17
- https://github.com/Yetangitu/Spodcast/issues/16

## Significant Changes:

- I have moved all my Dockerfiles related to Spodcast into the `docker` directory. That way we have a single source of truth for Spodcast's Docker stuff -- rather than having to point to [my Dockerfiles repository](https://github.com/heywoodlh/dockerfiles).

- I have added individual Dockerfiles for the following images:
    - [heywoodlh/spodcast](https://hub.docker.com/r/heywoodlh/spodcast)
    - [heywoodlh/spodcast-cront](https://hub.docker.com/r/heywoodlh/spodcast-cron) (This image runs cron within the container so Spodcast can run on a schedule independent of the Docker host)
    - [heywoodlh/spodcast-web](https://hub.docker.com/r/heywoodlh/spodcast-web)

- Docker-compose.yml has been added

- Updated the README on how to use the new `docker-compose.yml` file.

## Before Merging

I think that we should resolve https://github.com/Yetangitu/Spodcast/issues/17 and https://github.com/Yetangitu/Spodcast/issues/16 before this PR gets merged.
